### PR TITLE
Autoupdate dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
         schedule:
             interval: "weekly"
         open-pull-requests-limit: 5
+        allow:
+            - dependency-type: "development"


### PR DESCRIPTION
Follow-up on https://github.com/shipmonk-rnd/doctrine-mysql-index-hints/pull/5

Auto update only dev dependencies.

**Docs**
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow