### PR TITLE
CI: run checks even on fork PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,10 @@
 name: Checks
-on: [push]
+on:
+    pull_request:
+    push:
+        branches:
+            - "master"
+            - "v[0-9]"
 jobs:
     checks:
         runs-on: ubuntu-latest


### PR DESCRIPTION
- original idea: https://github.com/shipmonk-rnd/doctrine-mysql-index-hints/pull/2/files#r697339169
- push event does not work for forks
- pull_request does not cover direct pushes to master / v1 branches (although we should never do that, but protected branches does not handle that for now)