### PR TITLE
Use exact versions for dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         "nette/utils": ">=2.4.0"
     },
     "require-dev": {
-        "editorconfig-checker/editorconfig-checker": "^10.2.3",
-        "ergebnis/composer-normalize": "^2.28",
-        "phpstan/phpstan": "^1.7.14",
-        "phpstan/phpstan-phpunit": "^1.1.1",
-        "phpstan/phpstan-strict-rules": "^1.2.3",
-        "phpunit/phpunit": "^9.5.8",
-        "slevomat/coding-standard": "^8.1.0"
+        "editorconfig-checker/editorconfig-checker": "10.3.0",
+        "ergebnis/composer-normalize": "2.29.0",
+        "phpstan/phpstan": "1.9.14",
+        "phpstan/phpstan-phpunit": "1.3.3",
+        "phpstan/phpstan-strict-rules": "1.4.5",
+        "phpunit/phpunit": "9.5.28",
+        "slevomat/coding-standard": "8.8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Reasoning:
- prefer-lowest CI job wont affect dev dependencies
- fresh build in some new MR wont fail due to new rules in phpstan (and similar problems)
- dependabot should keep updating this latest version