### PR TITLE
get rid of deprecated method `Platform::getName`; include MariaDB as a part of MySQLPlatform

### DIFF
--- a/src/Doctrine/MySql/UseIndexHintHandler.php
+++ b/src/Doctrine/MySql/UseIndexHintHandler.php
@@ -2,7 +2,6 @@
 
 namespace ShipMonk\Doctrine\MySql;
 
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use LogicException;
 use ShipMonk\Doctrine\Walker\HintHandler;
@@ -37,7 +36,7 @@ class UseIndexHintHandler extends HintHandler
         $query = $sqlWalker->getQuery();
         $platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
 
-        if (!is_a($platform, AbstractMySQLPlatform::class)) {
+        if (!is_a($platform, 'Doctrine\DBAL\Platforms\AbstractMySQLPlatform')) {
             throw new LogicException(sprintf('Only MySQL platform is supported, %s given', $platform::class));
         }
 

--- a/src/Doctrine/MySql/UseIndexHintHandler.php
+++ b/src/Doctrine/MySql/UseIndexHintHandler.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\Doctrine\MySql;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use LogicException;
 use ShipMonk\Doctrine\Walker\HintHandler;
@@ -16,6 +17,7 @@ use function preg_match;
 use function preg_match_all;
 use function preg_quote;
 use function preg_replace;
+use function sprintf;
 
 class UseIndexHintHandler extends HintHandler
 {
@@ -35,8 +37,8 @@ class UseIndexHintHandler extends HintHandler
         $query = $sqlWalker->getQuery();
         $platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
 
-        if (!is_a($platform, 'Doctrine\DBAL\Platforms\MySqlPlatform')) { // bypass platform MySqlPlatform => MySQLPlatform rename in dbal
-            throw new LogicException("Only MySQL platform is supported, {$platform->getName()} given");
+        if (!is_a($platform, AbstractMySQLPlatform::class)) {
+            throw new LogicException(sprintf('Only MySQL platform is supported, %s given', $platform::class));
         }
 
         if (!$query->getAST() instanceof SelectStatement) {


### PR DESCRIPTION
some preparations for doctrine/dbal ^4.x