### PR TITLE
Update CI actions and add PHP 8.5 to matrix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
         steps:
             -
                 name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -38,7 +38,7 @@ jobs:
         steps:
             -
                 name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
         steps:
             -
                 name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -33,12 +33,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+                php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -
                 name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2


### PR DESCRIPTION
- Bump actions/checkout from v2 to v4
- Add PHP 8.5 to test matrix